### PR TITLE
Pull in batched infection time update

### DIFF
--- a/covid/impl/KCategorical.py
+++ b/covid/impl/KCategorical.py
@@ -1,0 +1,59 @@
+import tensorflow as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.internal import reparameterization
+tfd = tfp.distributions
+
+
+class KCategorical(tfd.Distribution):
+    def __init__(self,
+                 k,
+                 probs,
+                 validate_args=False,
+                 allow_nan_stats=True,
+                 name="Categorical"):
+        """K-Categorical distribution
+
+        Given a set of items indexed $1,...,n$ with weights $w_1,\dots,w_n$,
+        sample $k$ indices without replacement.
+        :param k: the number of indices to sample
+        :param probs: the (normalized) probability vector
+        :param validate_args: Whether to validate args
+        :param allow_nan_stats: allow nan stats
+        :param name: name of the distribution
+        """
+        parameters = dict(locals())
+        self.probs = probs
+        self.logits = tf.math.log(probs)
+        dtype = tf.int32
+
+        with tf.name_scope(name) as name:
+            super(KCategorical, self).__init__(
+                dtype=dtype,
+                reparameterization_type=reparameterization.FULLY_REPARAMETERIZED,
+                validate_args=validate_args,
+                allow_nan_stats=allow_nan_stats,
+                parameters=parameters,
+                name=name)
+
+    def _sample_n(self, n, seed=None):
+        g = tfd.Gumbel(0., 1.).sample(self.logits.shape, seed=seed)
+        z = g + self.logits
+        x = tf.argsort(z)
+        return x[:self.parameters['k']]
+
+    def _log_prob(self, x):
+        n = self.logits.shape
+        k = x.shape
+        wz = tf.gather(self.probs, x)
+        W = tf.cumsum(wz, reverse=True)
+        return tf.reduce_sum(wz - tf.math.log(W))
+
+
+if __name__=='__main__':
+    probs = tf.constant([1, 0, 0, 1, 1, 0, 1], dtype=tf.float32)
+    probs = probs/tf.reduce_sum(probs)
+    X = KCategorical(3, probs)
+    x = X.sample()
+    print(x)
+    lp = X.log_prob(x)
+    print(lp)

--- a/covid/impl/UniformInteger.py
+++ b/covid/impl/UniformInteger.py
@@ -47,6 +47,9 @@ class UniformInteger(tfd.Distribution):
                 parameters=parameters,
                 name=name)
         self.float_dtype = float_dtype
+        if validate_args is True:
+            tf.assert_greater(self._high, self._low,
+                              "Condition low < high failed")
 
     @staticmethod
     def _param_shapes(sample_shape):

--- a/covid/impl/event_time_proposal.py
+++ b/covid/impl/event_time_proposal.py
@@ -1,10 +1,12 @@
 """Mechanism for proposing event times to move"""
 import collections
-
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
+from pprint import pprint
 from covid.impl.UniformInteger import UniformInteger
+from covid.impl.KCategorical import KCategorical
 
 tfd = tfp.distributions
 
@@ -14,7 +16,15 @@ TransitionTopology = collections.namedtuple('TransitionTopology',
                                              'next'))
 
 
-def _abscumdiff(events, initial_state, target_id, bound_t, bound_id,
+def _events_or_inf(events, transition_id):
+    if transition_id is None:
+        return tf.fill(events.shape[:-1],
+                       tf.constant(np.inf, dtype=events.dtype))
+    return tf.gather(events, transition_id, axis=-1)
+
+
+
+def _abscumdiff(events, initial_state, topology, t, delta_t, bound_times,
                 int_dtype=tf.int32):
     """Returns the number of free events to move in target_events
        bounded by max([N_{target_id}(t)-N_{bound_id}(t)]_{bound_t}).
@@ -27,51 +37,46 @@ def _abscumdiff(events, initial_state, target_id, bound_t, bound_id,
               dtype=target_events.dtype
     """
 
-    # Broadcast rules for bound_t:
-    # ============================
-    # If bound_t is a scalar, it is broadcast to [M, 1]
-    # If bound_t is a 1-D tensor, it is broadcast to [M, bound_t.shape[0]]
-    # If bound_t is a 2-D tensor, leave alone
+    # This line prevents negative indices.  However, we must have
+    # a contract that the output of the algorithm is invalid!
+    bound_times = tf.clip_by_value(bound_times,
+                                   clip_value_min=0,
+                                   clip_value_max=events.shape[-2])
 
-    bound_t = tf.convert_to_tensor(bound_t)
-    if bound_t.shape.rank == 0:
-        bound_t = tf.broadcast_to(bound_t, [events.shape[0], 1])
-    elif bound_t.shape.rank == 1:
-        bound_t = tf.broadcast_to(bound_t, [events.shape[0], bound_t.shape[0]])
+    # Maybe replace with pad to avoid unstack/stack
+    prev_events = _events_or_inf(events, topology.prev)
+    target_events = tf.gather(events, topology.target, axis=-1)
+    next_events = _events_or_inf(events, topology.next)
+    event_tensor = tf.stack([prev_events, target_events, next_events],
+                            axis=-1)
 
-    def true_fn():
-        # Fetch events
-        target_events = tf.gather(events, target_id, axis=-1)  # MxT
-        bound_events = tf.gather(events, bound_id, axis=-1)  # MxT
+    # Compute the absolute cumulative difference between event times
+    diff = event_tensor[..., 1:] - event_tensor[..., :-1]  # [m, T, 2]
+    cumdiff = tf.abs(tf.cumsum(diff, axis=-2))  # cumsum along time axis
 
-        # Calculate event counting process
-        diff = target_events - bound_events
-        cumdiff = tf.abs(tf.cumsum(diff, axis=-1))
+    # Create indices into cumdiff [m, d_max, 2].  Last dimension selects
+    # the bound for either the previous or next event.
+    indices = tf.stack([
+        tf.repeat(tf.range(events.shape[0], dtype=int_dtype),
+                  [bound_times.shape[1]]),
+        tf.reshape(bound_times, [-1]),
+        tf.repeat(tf.where(delta_t < 0, 0, 1), [bound_times.shape[1]])
+    ], axis=-1)
+    indices = tf.reshape(indices, [events.shape[-3], bound_times.shape[1], 3])
+    free_events = tf.gather_nd(cumdiff, indices)
 
-        # TODO: check the validity of bound_id+1
-        bound_init_state = tf.gather(
-            initial_state,
-            target_id + tf.cast(bound_id > target_id, dtype=int_dtype),
-            axis=-1)
+    # Add on initial state
+    indices = tf.stack([tf.range(events.shape[0]),
+                        tf.where(delta_t[:, 0] < 0,
+                                 topology.target,
+                                 topology.target+1)],
+                       axis=-1)
+    bound_init_state = tf.gather_nd(initial_state,
+                                    indices)
+    free_events += bound_init_state[..., tf.newaxis]
 
-        indices = tf.stack([
-            tf.repeat(tf.range(cumdiff.shape[0], dtype=int_dtype),
-                      [bound_t.shape[1]]),
-            tf.reshape(bound_t, [-1])
-            ], axis=-1)
-        indices = tf.reshape(indices, [cumdiff.shape[0], bound_t.shape[1], 2])
-        free_events = tf.gather_nd(cumdiff, indices) + bound_init_state[:, None]
-        return free_events
+    return free_events
 
-    # Manual broadcasting of n_events_t is required here so that the XLA
-    # compiler can guarantee that the output shapes of true_fn() and
-    # false_fn() are equal.
-    def false_fn():
-        return int_dtype.max * tf.ones([events.shape[0]] + [bound_t.shape[1]],
-                                       dtype=events.dtype)
-
-    ret_val = tf.cond(bound_id != -1, true_fn, false_fn)
-    return ret_val
 
 
 class Deterministic2(tfd.Deterministic):
@@ -98,14 +103,7 @@ class Deterministic2(tfd.Deterministic):
         return tf.constant(1, dtype=self.log_prob_dtype)
 
 
-def TimeDelta(dmax, name=None):
-    outcomes = tf.concat([-tf.range(1, dmax + 1), tf.range(1, dmax + 1)],
-                         axis=0)
-    logits = tf.ones_like(outcomes, dtype=tf.float64)
-    return tfd.FiniteDiscrete(outcomes=outcomes, logits=logits, name=name)
-
-
-def EventTimeProposal(events, initial_state, topology, d_max, n_max,
+def EventTimeProposal(events, initial_state, topology, d_max, n_max, direction,
                       dtype=tf.int32, name=None):
     """Draws an event time move proposal.
     :param events: a [M, T, K] tensor of event times (M number of metapopulations,
@@ -123,9 +121,17 @@ def EventTimeProposal(events, initial_state, topology, d_max, n_max,
     def t_():
         x = tf.cast(target_events > 0, dtype=tf.float64)
         logits = tf.math.log(x)
-        return tfd.Multinomial(total_count=1, logits=tf.math.log(x), name='t_')
+        return tfd.Multinomial(total_count=1, logits=logits, name='t_')
+
+    def delta_t():
+        outcomes = tf.concat([-tf.range(1, d_max + 1), tf.range(1, d_max + 1)],
+                             axis=0)
+        logits = tf.ones([events.shape[-3]] + outcomes.shape, dtype=tf.float64)
+        return tfd.FiniteDiscrete(outcomes=outcomes, logits=logits,
+                                  name='delta_t')
 
     def t(t_):
+        # Waiting for fixed tf.nn.sparse_softmax_cross_entropy_with_logits
         #x = tf.cast(target_events > 0, dtype=tf.float64)  # [M, T]
         #return tfd.Categorical(logits=tf.math.log(x), name='event_coords')
         return Deterministic2(
@@ -133,31 +139,28 @@ def EventTimeProposal(events, initial_state, topology, d_max, n_max,
             log_prob_dtype=events.dtype,
             name='t')
 
-    def delta_t():
-        return TimeDelta(d_max, name='TimeDelta')
-
     def x_star(t, delta_t):
         # Compute bounds
         # The limitations of XLA mean that we must calculate bounds for
         # intervals [t, t+delta_t) if delta_t > 0, and [t+delta_t, t) if
         # delta_t is < 0.
         t = t[..., tf.newaxis]
-        bound_interval = tf.where(delta_t < 0,
-                                  t - time_interval - 1,  # [t+delta_t, t)
-                                  t + time_interval)  # [t, t+delta_t)
-
-        bound_event_id = tf.where(delta_t < 0,
-                                  topology.prev or -1,
-                                  topology.next or -1)
-
+        delta_t = delta_t[..., tf.newaxis]
+        bound_times = tf.where(delta_t < 0,
+                               t - time_interval - 1,  # [t+delta_t, t)
+                               t + time_interval)  # [t, t+delta_t)
         free_events = _abscumdiff(events=events, initial_state=initial_state,
-                                  target_id=topology.target,
-                                  bound_t=bound_interval,
-                                  bound_id=bound_event_id, int_dtype=dtype)
+                                  topology=topology,
+                                  t=t,
+                                  delta_t=delta_t,
+                                  bound_times=bound_times,
+                                  int_dtype=dtype)
+
         # Mask out bits of the interval we don't need for our delta_t
-        inf_mask = tf.cumsum(tf.one_hot(tf.math.abs(delta_t),
+        inf_mask = tf.cumsum(tf.one_hot(tf.math.abs(delta_t[:, 0]),
                                         d_max,
-                                        on_value=dtype.max,
+                                        on_value=tf.constant(np.inf,
+                                                             events.dtype),
                                         dtype=events.dtype))
         free_events = tf.maximum(inf_mask, free_events)
         free_events = tf.reduce_min(free_events, axis=-1)
@@ -168,10 +171,8 @@ def EventTimeProposal(events, initial_state, topology, d_max, n_max,
         max_events = tf.minimum(free_events, available_events)
         max_events = tf.clip_by_value(max_events, clip_value_min=0,
                                       clip_value_max=n_max)
-
         # Draw x_star
-        # Todo Lower bound must be 1.  We must *always* move something.
-        return UniformInteger(low=0, high=max_events + 1, name='x_star')
+        return UniformInteger(low=1, high=max_events+1)
 
     return tfd.JointDistributionNamed(dict(t_=t_,
                                            t=t,
@@ -179,19 +180,29 @@ def EventTimeProposal(events, initial_state, topology, d_max, n_max,
                                            x_star=x_star), name=name)
 
 
-def FilteredEventTimeProposal(events, initial_state, topology, d_max, n_max,
-                              dtype=tf.int32, name=None):
+def FilteredEventTimeProposal(events, initial_state, topology, m_max, d_max,
+                              n_max, direction, dtype=tf.int32, name=None):
     """FilteredEventTimeProposal allows us to choose a subset of indices
     in `range(events.shape[0])` for which to propose an update.  The
-    results are then broadcast back to `events.shape[0]`. """
+    results are then broadcast back to `events.shape[0]`.
+
+    :param events: a [M, T, X] event tensor
+    :param initial_state: a [M, S] initial state tensor
+    :param topology: a TransitionTopology named tuple describing the ordering
+                     of events
+    :param m: the number of metapopulations to move
+    :param d_max: maximum distance in time to move
+    :param n_max: maximum number of events to move (user defined)
+    :return: an instance of a JointDistributionNamed
+    """
     target_events = tf.gather(events, topology.target, axis=-1)
 
     def m():
         hot_meta = tf.math.count_nonzero(target_events, axis=1,
                                          keepdims=True) > 0
-        hot_meta = tf.reshape(hot_meta, [1, events.shape[0]])
-        logits = tf.math.log(tf.cast(hot_meta, tf.float64))
-        X = tfd.Categorical(logits=logits, name='m')
+        hot_meta = tf.cast(tf.transpose(hot_meta), dtype=events.dtype)
+        probs = hot_meta / tf.reduce_sum(hot_meta, axis=-1)
+        X = KCategorical(m_max, probs, name='m')
         return X
 
     def move(m):
@@ -203,7 +214,7 @@ def FilteredEventTimeProposal(events, initial_state, topology, d_max, n_max,
         select_meta = tf.gather(events, m, axis=0)
         select_init = tf.gather(initial_state, m, axis=0)
         return EventTimeProposal(select_meta, select_init, topology, d_max,
-                                 n_max, dtype=dtype, name=None)
+                                 n_max, direction=direction, dtype=dtype, name=None)
 
     return tfd.JointDistributionNamed(dict(m=m,
                                            move=move))

--- a/mcmc.py
+++ b/mcmc.py
@@ -20,6 +20,10 @@ from covid.impl.event_time_mh import EventTimesUpdate
 
 DTYPE = config.floatX
 
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+tf.random.set_seed(10)
+
 # Random moves of events.  What invalidates an epidemic, how can we test for it?
 with open('ode_config.yaml', 'r') as f:
     config = yaml.load(f)
@@ -78,11 +82,6 @@ def logp(par, events):
     return logp
 
 
-def trace_fn(state, prev_results):
-    return (prev_results.is_accepted,
-            prev_results.accepted_results.target_log_prob)
-
-
 # Pavel's suggestion for a Gibbs kernel requires
 # kernel factory functions.
 def make_parameter_kernel(scale, bounded_convergence):
@@ -103,9 +102,9 @@ def make_events_step(target_event_id, prev_event_id=None, next_event_id=None):
                                 target_event_id=target_event_id,
                                 prev_event_id=prev_event_id,
                                 next_event_id=next_event_id,
-                                dmax=1,
-                                mmax=1,
-                                nmax=20,
+                                dmax=2,
+                                mmax=2,
+                                nmax=10,
                                 initial_state=state_init)
 
     return kernel_func
@@ -131,8 +130,7 @@ def sample(n_samples, init_state, par_scale):
     init_state = init_state.copy()
     par_func = make_parameter_kernel(par_scale, 0.95)
     se_func = make_events_step(0, None, 1)
-    ei_func = make_events_step(target_event_id=1, prev_event_id=0,
-                               next_event_id=2)
+    ei_func = make_events_step(1, 0, 2)
 
     # Based on Gibbs idea posted by Pavel Sountsov
     # https://github.com/tensorflow/probability/issues/495
@@ -179,6 +177,11 @@ def sample(n_samples, init_state, par_scale):
 
 
 if __name__ == '__main__':
+
+    if tf.test.gpu_device_name():
+        print('Using GPU')
+    else:
+        print("Using CPU")
 
     num_loop_iterations = 1000
     num_loop_samples = 100

--- a/mcmc.py
+++ b/mcmc.py
@@ -180,7 +180,7 @@ def sample(n_samples, init_state, par_scale):
 
 if __name__ == '__main__':
 
-    num_loop_iterations = 10
+    num_loop_iterations = 1000
     num_loop_samples = 100
     current_state = [np.array([0.15, 0.25], dtype=DTYPE),
                      tf.stack([se_events, ei_events, ir_events], axis=-1)]


### PR DESCRIPTION
Over the weekend, I managed to batch the event time updates together.  Each meta-population now gets a different `delta_t` by which to move events.  

There is a weird bug in the XLA-compiled version.  Running on my stack with the prescribed seed (N.B. CPU-only mode), the XLA compiled code runs to about 48000 iterations then just hangs.  In XLA mode I can't print anything out to trace the functions, so am having difficulty working out where the fault is.  